### PR TITLE
the server breaks down if a package does not exists in the pub.dartlang.org

### DIFF
--- a/example/src/examples/http_proxy_repository.dart
+++ b/example/src/examples/http_proxy_repository.dart
@@ -29,16 +29,24 @@ class HttpProxyRepository extends PackageRepository {
           baseUrl.resolve('/api/packages/${Uri.encodeComponent(package)}');
 
       http.Response response = await client.get(versionUrl);
-      var json = JSON.decode(response.body);
-      var versions = json['versions'];
-      if (versions != null) {
-        return versions.map((Map item) {
-          var pubspec = item['pubspec'];
-          var pubspecString = JSON.encode(pubspec);
-          return new PackageVersion(
-              pubspec['name'], pubspec['version'], pubspecString);
-        }).toList();
+
+      try {
+        var json = JSON.decode(response.body);
+        var versions = json['versions'];
+        if (versions != null) {
+          return versions.map((Map item) {
+            var pubspec = item['pubspec'];
+            var pubspecString = JSON.encode(pubspec);
+            return new PackageVersion(
+                pubspec['name'], pubspec['version'], pubspecString);
+          }).toList();
+        }
+
+      } on FormatException catch (e) {
+        print(e.message);
+
       }
+
       return const [];
     }
 


### PR DESCRIPTION
If we publish some ourselves package `pub publish` and try to get it  `pub get` - the server breaks down with an exception:

```
Asynchronous error
FormatException: Unexpected character (at character 1)
Not Found
^

dart:convert                                           JsonCodec.decode
example/src/examples/http_proxy_repository.dart 32:23  HttpProxyRepository.versions.fetch.<async>
```

I have tried to fix it.
