### PR TITLE
Run without connecting to pub.dartlang.org using standalone option

### DIFF
--- a/example/server.dart
+++ b/example/server.dart
@@ -23,7 +23,7 @@ main(List<String> args) {
   var directory = results['directory'];
   var host = results['host'];
   var port = int.parse(results['port']);
-  var standalone = results['standalone'] == 'true';
+  var standalone = results['standalone'];
 
   if (results.rest.length > 0) {
     print('Got unexpected arguments: "${results.rest.join(' ')}".\n\nUsage:\n');
@@ -61,7 +61,7 @@ ArgParser argsParser() {
   parser.addOption('host', abbr: 'h', defaultsTo: 'localhost');
 
   parser.addOption('port', abbr: 'p', defaultsTo: '8080');
-  parser.addOption('standalone', abbr: 's', defaultsTo: 'false');
+  parser.addFlag('standalone', abbr: 's', defaultsTo: false);
   return parser;
 }
 

--- a/example/server.dart
+++ b/example/server.dart
@@ -23,23 +23,24 @@ main(List<String> args) {
   var directory = results['directory'];
   var host = results['host'];
   var port = int.parse(results['port']);
+  var standalone = results['standalone'] == 'true';
 
   if (results.rest.length > 0) {
     print('Got unexpected arguments: "${results.rest.join(' ')}".\n\nUsage:\n');
     print(parser.usage);
     exit(1);
   }
-
+  
   setupLogger();
-  runPubServer(directory, host, port);
+  runPubServer(directory, host, port, standalone);
 }
 
-runPubServer(String baseDir, String host, int port) {
+runPubServer(String baseDir, String host, int port, bool standalone) {
   var client = new http.Client();
 
   var local = new FileRepository(baseDir);
   var remote = new HttpProxyRepository(client, PubDartLangOrg);
-  var cow = new CopyAndWriteRepository(local, remote);
+  var cow = new CopyAndWriteRepository(local, remote, standalone);
 
   var server = new ShelfPubServer(cow);
   print('Listening on http://$host:$port\n'
@@ -60,6 +61,7 @@ ArgParser argsParser() {
   parser.addOption('host', abbr: 'h', defaultsTo: 'localhost');
 
   parser.addOption('port', abbr: 'p', defaultsTo: '8080');
+  parser.addOption('standalone', abbr: 's', defaultsTo: 'false');
   return parser;
 }
 

--- a/example/src/examples/cow_repository.dart
+++ b/example/src/examples/cow_repository.dart
@@ -43,13 +43,13 @@ class CopyAndWriteRepository extends PackageRepository {
       var waitList = [
         _localCache.fetchVersionlist(package)
       ];
-      if(standalone != true){
-        waitList..add(_remoteCache.fetchVersionlist(package));
+      if (standalone != true) {
+        waitList.add(_remoteCache.fetchVersionlist(package));
       }
       Future.wait(waitList).then((tuple) {
         var versions = new Set()..addAll(tuple[0]);
-        if(standalone != true){
-          versions..addAll(tuple[1]);
+        if (standalone != true) {
+          versions.addAll(tuple[1]);
         }
         for (var version in versions) controller.add(version);
         controller.close();


### PR DESCRIPTION
In an isolated dome (no internet connectivity) env with the help of this option pub server can be a read only server, prerequisite is that packages need to be present in the DB folder beforehand. `pub publish` isn't possible as it require oauth and the env itself is meant to have no internet connectivity.