### PR TITLE
Add hasDocumentation flag to PackageVersion.

### DIFF
--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -19,6 +19,8 @@ class PackageVersion {
   /// The pubspec yaml file of the package
   final String pubspecYaml;
 
+  final bool hasDocumentation;
+
   Version _cached;
 
   /// The version of the package as a [Version] object.
@@ -28,7 +30,8 @@ class PackageVersion {
     return _cached;
   }
 
-  PackageVersion(this.packageName, this.versionString, this.pubspecYaml);
+  PackageVersion(this.packageName, this.versionString, this.pubspecYaml,
+      {this.hasDocumentation});
 
   @override
   int get hashCode =>

--- a/lib/shelf_pubserver.dart
+++ b/lib/shelf_pubserver.dart
@@ -248,22 +248,23 @@ class ShelfPubServer {
 
     packageVersions.sort((a, b) => a.version.compareTo(b.version));
 
-    var latestVersion = packageVersions.last;
+    int latestVersionIndex = packageVersions.length - 1;
     for (int i = packageVersions.length - 1; i >= 0; i--) {
       if (!packageVersions[i].version.isPreRelease) {
-        latestVersion = packageVersions[i];
+        latestVersionIndex = i;
         break;
       }
     }
+    final versionsData = packageVersions
+        .map((pv) => _defaultPackageVersionJson(uri, pv))
+        .toList();
 
     // TODO: The 'latest' is something we should get rid of, since it's
     // duplicated in 'versions'.
     var binaryJson = JSON.encoder.fuse(UTF8.encoder).convert({
       'name': package,
-      'latest': _defaultPackageVersionJson(uri, latestVersion),
-      'versions': packageVersions
-          .map((pv) => _defaultPackageVersionJson(uri, pv))
-          .toList(),
+      'latest': versionsData[latestVersionIndex],
+      'versions': versionsData,
     });
     if (cache != null) {
       await cache.setPackageData(package, binaryJson);

--- a/lib/shelf_pubserver.dart
+++ b/lib/shelf_pubserver.dart
@@ -285,12 +285,16 @@ class ShelfPubServer {
   Map<String, dynamic> _defaultPackageVersionJson(
       Uri uri, PackageVersion version) {
     // TODO: Add legacy entries (if necessary), such as version_url.
-    return {
+    final map = {
       'archive_url': '${_downloadUrl(
     uri, version.packageName, version.versionString)}',
       'pubspec': loadYaml(version.pubspecYaml),
       'version': version.versionString,
     };
+    if (version.hasDocumentation != null) {
+      map['hasDocumentation'] = version.hasDocumentation;
+    }
+    return map;
   }
 
   // Download handlers.


### PR DESCRIPTION
Required change for https://github.com/dart-lang/pub-dartlang-dart/issues/1119

/cc @jakobr-google 

@kevmoo: instead of overriding the map, adding the explicit flag seemed better.