### PR TITLE
Fixed type cast error

### DIFF
--- a/example/src/examples/http_proxy_repository.dart
+++ b/example/src/examples/http_proxy_repository.dart
@@ -28,7 +28,7 @@ class HttpProxyRepository extends PackageRepository {
 
     http.Response response = await client.get(versionUrl);
     var json = convert.json.decode(response.body);
-    var versions = json['versions'] as List<Map>;
+    var versions = json['versions'];
     if (versions != null) {
       for (var item in versions) {
         var pubspec = item['pubspec'];


### PR DESCRIPTION
When running the example repository on dart 2.0.0 I always get:
```
Asynchronous error
type 'List<dynamic>' is not a subtype of type 'List<Map<dynamic, dynamic>>' in type cast
dart:core                                              Object._as
example/src/examples/http_proxy_repository.dart 31:37  HttpProxyRepository.versions
===== asynchronous gap ===========================
example/src/examples/cow_repository.dart 135:18        _RemoteMetadataCache.fetchVersionlist.<fn>
dart:collection                                        __InternalLinkedHashMap&_HashVMBase&MapMixin&_LinkedHashMapMixin.putIfAbsent
example/src/examples/cow_repository.dart 131:10        _RemoteMetadataCache.fetchVersionlist
example/src/examples/cow_repository.dart 47:35         CopyAndWriteRepository.versions.onListen
dart:async                                             Stream.toList
package:pub_server/shelf_pubserver.dart 242:62         ShelfPubServer._listVersions
```
The change proposed fixed the problem.